### PR TITLE
Add additional links to the Projects page

### DIFF
--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -18,6 +18,5 @@ const artworks_newest_first = computed<Thumbnail[]>(() => {
     <template v-for="thumbnail in artworks_newest_first" :key="thumbnail.sort_key">
       <ThumbnailCard :card="thumbnail" />
     </template>
-    <div class="plaque" v-show="true">🚧 Curating old artworks, check back later for more!</div>
   </div>
 </template>

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -21,11 +21,36 @@ const projects_newest_first = computed<Thumbnail[]>(() => {
     <template v-for="thumbnail in projects_newest_first" :key="thumbnail.sort_key">
       <ThumbnailCard :card="thumbnail" />
     </template>
+  </div>
+
+  <div class="tableau">
     <div class="plaque" v-show="true">
-      <p>🚧 Curating old projects, check back later for more!</p>
+      <h2>Other Projects</h2>
       <p>
-        For a list of my other programming projects, see my
-        <a href="https://github.com/ptrgags?tab=repositories">GitHub repositories</a>
+        Going further back in time, I have other projects I have yet to document here. Here are some
+        of the notable ones:
+      </p>
+      <ul>
+        <li>
+          Drawing Machines (2019) - <a href="https://ptrgags.dev/drawing-machines/">Demo</a>,
+          <a href="https://github.com/ptrgags/drawing-machines">GitHub</a>
+        </li>
+        <li>
+          Virtual Museum (2019) - <a href="https://museum.shaders.dev/">Demo</a>,
+          <a href="https://github.com/ptrgags/virtual-museum">GitHub</a>
+        </li>
+        <li>
+          Holiday Eyecandy (2018) - <a href="https://ptrgags.dev/holiday-eyecandy/">Demo</a>,
+          <a href="https://github.com/ptrgags/holiday-eyecandy">GitHub</a>
+        </li>
+        <li>
+          Ant Farm (2015) - <a href="https://ptrgags.dev/ant-farm/">Demo</a>,
+          <a href="https://github.com/ptrgags/ant-farm">GitHub</a>
+        </li>
+      </ul>
+      <p>
+        For the full list of my programming projects, see my
+        <a href="https://github.com/ptrgags?tab=repositories">GitHub repositories</a>.
       </p>
     </div>
   </div>

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -27,8 +27,8 @@ const projects_newest_first = computed<Thumbnail[]>(() => {
     <div class="plaque" v-show="true">
       <h2>Other Projects</h2>
       <p>
-        Going further back in time, I have other projects I have yet to document here. Here are some
-        of the notable ones:
+        Going further back in time, I have more projects not documented here. Here are links to some
+        of the notable ones.
       </p>
       <ul>
         <li>


### PR DESCRIPTION
This PR just changes the under construction section of the Projects page to be a list of specific projects I haven't documented.

I also removed the under construction section of the Gallery page.