### PR TITLE
fix image loading jank

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,31 +3,29 @@ import { RouterView } from 'vue-router'
 
 import Navbar from './components/Navbar.vue'
 
-import "@/assets/global.css"
+import '@/assets/global.css'
 </script>
 
 <template>
-    <Navbar />
-    <div class="content">
-        <RouterView />
-    </div>
+  <Navbar />
+  <div class="content">
+    <RouterView />
+  </div>
 </template>
 
 <style>
 body {
-    background-image: url("assets/background.png");
-    background-repeat: repeat;
-    font-family: sans-serif;
-    margin: 0;
+  background-image: url('assets/background.png');
+  background-repeat: repeat;
+  font-family: sans-serif;
 }
 
 .content {
-    background-color: rgba(0, 0, 0, 0.5);
-    color: white;
-    min-height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
 }
 
 .content h1 {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 </style>

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -1,3 +1,9 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
 :root {
   /** Color for all of the text */
   --color-text: #ececec;
@@ -81,6 +87,7 @@ kbd {
 
   /* Shrink the image if it's too wide for the screen */
   max-width: 100%;
+  object-fit: cover;
 
   background-color: var(--background-text);
 }

--- a/src/components/CardImage.vue
+++ b/src/components/CardImage.vue
@@ -11,6 +11,14 @@ const size = computed(() => {
   return props.image.size ?? 'thumbnail'
 })
 
+const width = computed(() => {
+  return size.value === 'thumbnail' ? '250' : '500'
+})
+
+const height = computed(() => {
+  return size.value === 'thumbnail' ? '350' : '750'
+})
+
 const placeholder_url = computed(() => {
   // See public/assets in the repo
   return `/assets/placeholder-${size.value}.png`
@@ -36,6 +44,6 @@ function handle_error(event: Event) {
 
 <template>
   <MaybeLink :url="props.image.link">
-    <img :src="img_url" :alt="alt_text" @error="handle_error" />
+    <img :src="img_url" :width="width" :height="height" :alt="alt_text" @error="handle_error" />
   </MaybeLink>
 </template>


### PR DESCRIPTION
In another repo (...`p5-sketchbook` I think?) I learned that you need to counterintuitively set width/height on the the `<img>` tag so the browser knows how much space to reserve for images. Applying this to the website