### PR TITLE
Add deployment workflow from other repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - deployment-workflow
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+      - deployment-workflow
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install npm stuff
+        run: npm install
+      - name: Build the static site in dist/
+        run: npm run build
+      - name: Upload static files
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -28,24 +28,6 @@ npm run dev
 
 ### Release
 
-After merging all PRs with content update into `main`, I follow these steps
-to publish to `gh-pages`. I use a second copy of the repo cloned elsewhere.
-
-For the example below, the main repo is `/path/to/website`, and the
-`gh-pages` version is `/path/to/website-publish`.
-
-```sh
-# This makes a build in the dist/ subdirectory
-cd /path/to/website/
-npm run build
-
-# remove the old build files and add the new ones
-cd /path/to/website-publish/
-rm -r *
-cp -r /path/to/website/dist/* .
-
-# Using a static file server (such as http-server), host the publish directory
-# and double check that everything looks right.
-
-# Finally, check in the changes to gh-pages and push to GH
-```
+I have a GitHub Action configured (see `.github/workflows/deploy.yml`) to
+automatically deploy the website to GitHub pages whenever something is merged
+into `main`. After merging a PR, double check that this happened successfully.


### PR DESCRIPTION
I tried using a GitHub Action to make deployments automatic for `webgpu-sketchbook`. The same action applies just as well to the main website